### PR TITLE
Error handling

### DIFF
--- a/py_noaa/coops.py
+++ b/py_noaa/coops.py
@@ -52,6 +52,11 @@ def url2pandas(data_url):
     response = requests.get(data_url)        # get json data from url
     json_str = response.text                 # json as a string 
     json_dict = json.loads(json_str)         # convert json string to a dictionary for parsing
+
+    if 'error' in json_dict:
+        raise ValueError(
+            json_dict['error'].get('message', 'Error retrieving data'))
+
     df = json_normalize(json_dict['data'])   # parse json dictionary for data into dataframe
     
     return df

--- a/py_noaa/coops.py
+++ b/py_noaa/coops.py
@@ -20,7 +20,7 @@ def build_query_url(begin_date, end_date, stationid, product, datum=None, bin_nu
     # if the data product is water levels, check that a datum is specified
     if product=='water_level':
         if datum==None:
-            sys.exit('ERROR! No datum specified for water level data. See https://tidesandcurrents.noaa.gov/api/#datum for list of available datums')
+            raise ValueError('No datum specified for water level data. See https://tidesandcurrents.noaa.gov/api/#datum for list of available datums')
         else:   
             # compile parameter string for use in URL
             parameters = ['begin_date='+begin_date, 'end_date='+end_date, 'station='+stationid, 'product='+product, 'datum='+datum, 'units='+units, 'time_zone='+time_zone,'application=web_services','format=json']
@@ -28,7 +28,7 @@ def build_query_url(begin_date, end_date, stationid, product, datum=None, bin_nu
     # if the data product is currents, check that a bin number is specified
     elif product=='currents':
         if bin_num==None:
-            sys.exit('ERROR! No bin specified for current data. Bin info can be found on the station info page (e.g., https://tidesandcurrents.noaa.gov/cdata/StationInfo?id=PUG1515)')
+            raise ValueError('No bin specified for current data. Bin info can be found on the station info page (e.g., https://tidesandcurrents.noaa.gov/cdata/StationInfo?id=PUG1515)')
         else:    
             # compile parameter string for use in URL
             parameters = ['begin_date='+begin_date, 'end_date='+end_date, 'station='+stationid, 'product='+product, 'bin='+str(bin_num), 'units='+units, 'time_zone='+time_zone,'application=web_services','format=json']


### PR DESCRIPTION
Hey there! looks like a great package :) Would you be open to pull requests?

I've added some error handling (reporting NOAA errors when the API responds with errors), e.g.:

    In [3]: coops.get_data(
       ...:     begin_date="20150727",
       ...:     end_date="20150910",
       ...:     stationid="8723214",
       ...:     product="water_level",
       ...:     bin_num=1,
       ...:     units="metric",
       ...:     time_zone="gmt",
       ...:     datum='navd88')
       ...:
    ---------------------------------------------------------------------------
    ValueError                                Traceback (most recent call last)
    ...
    ValueError:  The supported Datum values are: MHHW, MHW, MTL, MSL, MLW, MLLW, NAVD, LWI, HWI

I've also changed `sys.exit` to `raise ValueError` (see guidance here: https://docs.python.org/3/library/exceptions.html#ValueError)