### PR TITLE
Fix interval functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This package is under development, additional modules will be added as use cases
 ---
 `pip install py_noaa`
 
+You can update `py_noaa` using:
+
+`pip install py_noaa --upgrade`
+
 ## Available Modules & Data:
 ---
 - [NOAA CO-OPS Tides & Currents](https://tidesandcurrents.noaa.gov/)
@@ -24,7 +28,7 @@ py_noaa accesses data following the [NOAA CO-OPS API](https://tidesandcurrents.n
 <br>
 ### **CO-OPS module basics**
 ---
-1. Get the station ID for the station of interest, a summary of available stations, by data type, can be found through the following links:
+1. Get the station ID for your station of interest, a summary of available stations, by data type, can be found through the following links:
 
     - [Water Level Observation Stations](https://tidesandcurrents.noaa.gov/stations.html?type=Water+Levels)
     - [Tidal Prediction Stations](https://tidesandcurrents.noaa.gov/tide_predictions.html)
@@ -39,7 +43,12 @@ py_noaa accesses data following the [NOAA CO-OPS API](https://tidesandcurrents.n
 - Currents
 - Observed water levels
 - Predicted water levels (tides)
+- Winds
+- Air pressure
+- Air temperature
+- Water temperature
 
+Compatibility with other data products listed on the [NOAA CO-OPS API](https://tidesandcurrents.noaa.gov/api/#products) may exist but is not guaranteed at this time.
 
 ### Examples data requests are shown below:
 
@@ -57,12 +66,13 @@ py_noaa accesses data following the [NOAA CO-OPS API](https://tidesandcurrents.n
 ...     time_zone="gmt")
 ...
 >>> df_currents.head()
-   bin  direction  speed           date_time
-0  1.0      255.0   32.1 2015-07-27 20:06:00
-1  1.0      255.0   30.1 2015-07-27 20:12:00
-2  1.0      261.0   29.3 2015-07-27 20:18:00
-3  1.0      260.0   27.3 2015-07-27 20:24:00
-4  1.0      261.0   23.0 2015-07-27 20:30:00
+                     bin  direction  speed
+date_time
+2015-07-27 20:06:00  1.0      255.0   32.1
+2015-07-27 20:12:00  1.0      255.0   30.1
+2015-07-27 20:18:00  1.0      261.0   29.3
+2015-07-27 20:24:00  1.0      260.0   27.3
+2015-07-27 20:30:00  1.0      261.0   23.0
 
 ```
 
@@ -73,23 +83,26 @@ py_noaa accesses data following the [NOAA CO-OPS API](https://tidesandcurrents.n
 >>> df_water_levels = coops.get_data(
 ...     begin_date="20150101",
 ...     end_date="20150331",
-...     stationid="9442396",
+...     stationid="9447130",
 ...     product="water_level",
 ...     datum="MLLW",
 ...     units="metric",
 ...     time_zone="gmt")
 ...
 >>> df_water_levels.head()
-     flags QC  sigma           date_time  water_level
-0  0,0,0,0  v  0.006 2015-01-01 00:00:00       -0.045
-1  0,0,0,0  v  0.008 2015-01-01 00:06:00       -0.028
-2  0,0,0,0  v  0.017 2015-01-01 00:12:00       -0.021
-3  0,0,0,0  v  0.009 2015-01-01 00:18:00        0.008
-4  0,0,0,0  v  0.006 2015-01-01 00:24:00        0.026
+                       flags QC  sigma  water_level
+date_time
+2015-01-01 00:00:00  0,0,0,0  v  0.023        1.799
+2015-01-01 01:00:00  0,0,0,0  v  0.014        0.977
+2015-01-01 02:00:00  0,0,0,0  v  0.009        0.284
+2015-01-01 03:00:00  0,0,0,0  v  0.010       -0.126
+2015-01-01 04:00:00  0,0,0,0  v  0.013       -0.161
 
 ```
 
 **Predicted Water Levels (Tides)**
+
+Note the use of the `interval` parameter to specify only hourly data be returned. The `interval` parameter works with, water level, currents, predictions, and meteorological data types.
 
 ```python
 >>> from py_noaa import coops
@@ -113,6 +126,40 @@ py_noaa accesses data following the [NOAA CO-OPS API](https://tidesandcurrents.n
 
 ```
 
+**Filtering Data by date**
+
+All data is returned as a pandas dataframe, with a DatimeIndex which allows for easy filtering of the data by dates.
+
+```python
+>>> from py_noaa import coops
+>>> df_predictions = coops.get_data(
+...     begin_date="20121115",
+...     end_date="20121217",
+...     stationid="9447130",
+...     product="predictions",
+...     datum="MLLW",
+...     interval="h",
+...     units="metric",
+...     time_zone="gmt")
+...
+>>> df_predictions['201211150000':'201211151200']
+                     predicted_wl
+date_time
+2012-11-15 00:00:00         3.660
+2012-11-15 01:00:00         3.431
+2012-11-15 02:00:00         2.842
+2012-11-15 03:00:00         1.974
+2012-11-15 04:00:00         0.953
+2012-11-15 05:00:00        -0.047
+2012-11-15 06:00:00        -0.787
+2012-11-15 07:00:00        -1.045
+2012-11-15 08:00:00        -0.740
+2012-11-15 09:00:00         0.027
+2012-11-15 10:00:00         1.053
+2012-11-15 11:00:00         2.114
+2012-11-15 12:00:00         3.006
+```
+
 ### Exporting Data 
 ---
 Since data is returned in a pandas dataframe, exporting the data is simple using the `.to_csv` method on the returned pandas dataframe. This requires the [pandas](https://pandas.pydata.org/) package, which should be taken care of if you installed `py_noaa` with `pip`.
@@ -130,12 +177,11 @@ Since data is returned in a pandas dataframe, exporting the data is simple using
 >>> df_currents.to_csv(
 ...     'example.csv',
 ...     sep='\t',
-...     encoding='utf-8',
-...     index=False)
+...     encoding='utf-8')
 
 ```
 
-As shwon above, you can set the delimeter type using the `sep=` argument in the `.to_csv` method and control the file encoding using the `encoding=` argument. Setting `index=False` will prevent the index of the pandas dataframe from being inlcuded in the exported csv file.
+As shown above, you can set the delimeter type using the `sep=` argument in the `.to_csv` method and control the file encoding using the `encoding=` argument.
 
 ## Requirements
 ---
@@ -162,5 +208,5 @@ The development of py_noaa was originally intended to help me ([@GClunies](https
 As this project started as a learning exercise, please be patient and willing to teach/learn.
 
 
-**Many thanks needs to be given to the following contributors!**
+**Many thanks to the following contributors!**
 - [@delgadom](https://github.com/delgadom)  

--- a/py_noaa/coops.py
+++ b/py_noaa/coops.py
@@ -45,10 +45,18 @@ def build_query_url(begin_date,
                           'format=json']
 
     elif product=='predictions':
+        # if no interval provided, return 6-min predictions data
         if interval==None:
-            raise ValueError('No interval specified for water level predictions.'
-                        ' See https://tidesandcurrents.noaa.gov/api/#interval'
-                        ' for list of available intervals')
+            # compile parameter string for use in URL
+            parameters = ['begin_date='+begin_date, 
+                          'end_date='+end_date, 
+                          'station='+stationid, 
+                          'product='+product, 
+                          'datum='+datum, 
+                          'units='+units, 
+                          'time_zone='+time_zone,
+                          'application=web_services',
+                          'format=json']
         else:   
             # compile parameter string for use in URL
             parameters = ['begin_date='+begin_date, 
@@ -81,12 +89,25 @@ def build_query_url(begin_date,
                           'format=json']
     
     # for all other data types (e.g., meteoroligcal conditions)
-    else:    
-        # compile parameter string for use in URL
-        parameters = ['begin_date='+begin_date, 
+    else:
+        # if no interval provided, return 6-min met data
+        if interval==None:    
+            # compile parameter string for use in URL
+            parameters = ['begin_date='+begin_date, 
                       'end_date='+end_date, 
                       'station='+stationid, 
                       'product='+product, 
+                      'units='+units, 
+                      'time_zone='+time_zone, 
+                      'application=web_services', 
+                      'format=json']
+        else:    
+            # compile parameter string for use in URL
+            parameters = ['begin_date='+begin_date, 
+                      'end_date='+end_date, 
+                      'station='+stationid, 
+                      'product='+product,
+                      'interval='+interval, 
                       'units='+units, 
                       'time_zone='+time_zone, 
                       'application=web_services', 
@@ -245,5 +266,63 @@ def get_data(begin_date,
         
         # convert date & time strings to datetime objects
         df['date_time'] = pd.to_datetime(df['date_time'])
+
+    elif product == 'wind':
+        # rename columns for clarity
+        df.rename(columns = {'d': 'dir', 'dr': 'compass',
+                             'f': 'flags', 'g': 'gust_spd',
+                             's': 'spd', 't': 'date_time'},
+                             inplace=True)
+        
+        # convert columns to numeric values
+        data_cols = df.columns.drop(['date_time', 'flags', 'compass'])
+        df[data_cols] = df[data_cols].apply(pd.to_numeric, axis=1, errors='coerce')
+        
+        # convert date & time strings to datetime objects
+        df['date_time'] = pd.to_datetime(df['date_time'])
+
+    elif product == 'air_pressure':
+        # rename columns for clarity
+        df.rename(columns = {'f': 'flags', 't': 'date_time', 'v':'air_press'},
+                             inplace=True)
+        
+        # convert columns to numeric values
+        data_cols = df.columns.drop(['date_time', 'flags'])
+        df[data_cols] = df[data_cols].apply(pd.to_numeric, axis=1, errors='coerce')
+        
+        # convert date & time strings to datetime objects
+        df['date_time'] = pd.to_datetime(df['date_time'])
+
+    elif product == 'air_temperature':
+        # rename columns for clarity
+        df.rename(columns = {'f': 'flags', 't': 'date_time', 'v':'air_temp'},
+                             inplace=True)
+        
+        # convert columns to numeric values
+        data_cols = df.columns.drop(['date_time', 'flags'])
+        df[data_cols] = df[data_cols].apply(pd.to_numeric, axis=1, errors='coerce')
+        
+        # convert date & time strings to datetime objects
+        df['date_time'] = pd.to_datetime(df['date_time'])
+
+    elif product == 'water_temperature':
+        # rename columns for clarity
+        df.rename(columns = {'f': 'flags', 't': 'date_time', 'v':'water_temp'},
+                             inplace=True)
+        
+        # convert columns to numeric values
+        data_cols = df.columns.drop(['date_time', 'flags'])
+        df[data_cols] = df[data_cols].apply(pd.to_numeric, axis=1, errors='coerce')
+        
+        # convert date & time strings to datetime objects
+        df['date_time'] = pd.to_datetime(df['date_time'])
+
+
+    df.index = df['date_time']    # set datetime to index (for use in resampling)
+    df = df.drop(columns=['date_time'])
+
+    # handle hourly requests for water_level and currents data
+    if (product == 'water_level') | (product == 'currents') & (interval == 'h'):
+        df = df.resample('H').first()    # only return the hourly data
 
     return df

--- a/py_noaa/coops.py
+++ b/py_noaa/coops.py
@@ -41,7 +41,7 @@ def build_query_url(begin_date,
                           'datum='+datum, 
                           'units='+units, 
                           'time_zone='+time_zone,
-                          'application=web_services',
+                          'application=py_noaa',
                           'format=json']
 
     elif product=='predictions':
@@ -55,7 +55,7 @@ def build_query_url(begin_date,
                           'datum='+datum, 
                           'units='+units, 
                           'time_zone='+time_zone,
-                          'application=web_services',
+                          'application=py_noaa',
                           'format=json']
         else:   
             # compile parameter string for use in URL
@@ -67,7 +67,7 @@ def build_query_url(begin_date,
                           'interval='+interval, 
                           'units='+units, 
                           'time_zone='+time_zone,
-                          'application=web_services',
+                          'application=py_noaa',
                           'format=json']
 
     # if the data product is currents, check that a bin number is specified
@@ -85,7 +85,7 @@ def build_query_url(begin_date,
                           'bin='+str(bin_num), 
                           'units='+units, 
                           'time_zone='+time_zone, 
-                          'application=web_services', 
+                          'application=py_noaa', 
                           'format=json']
     
     # for all other data types (e.g., meteoroligcal conditions)
@@ -99,7 +99,7 @@ def build_query_url(begin_date,
                       'product='+product, 
                       'units='+units, 
                       'time_zone='+time_zone, 
-                      'application=web_services', 
+                      'application=py_noaa', 
                       'format=json']
         else:    
             # compile parameter string for use in URL
@@ -110,7 +110,7 @@ def build_query_url(begin_date,
                       'interval='+interval, 
                       'units='+units, 
                       'time_zone='+time_zone, 
-                      'application=web_services', 
+                      'application=py_noaa', 
                       'format=json']
 
     parameters_url = '&'.join(parameters)    # join parameters to single string

--- a/py_noaa/coops.py
+++ b/py_noaa/coops.py
@@ -58,7 +58,7 @@ def build_query_url(begin_date,
                           'application=py_noaa',
                           'format=json']
         else:   
-            # compile parameter string for use in URL
+            # compile parameter string, including interval, for use in URL
             parameters = ['begin_date='+begin_date, 
                           'end_date='+end_date, 
                           'station='+stationid, 
@@ -102,7 +102,7 @@ def build_query_url(begin_date,
                       'application=py_noaa', 
                       'format=json']
         else:    
-            # compile parameter string for use in URL
+            # compile parameter string, including interval, for use in URL
             parameters = ['begin_date='+begin_date, 
                       'end_date='+end_date, 
                       'station='+stationid, 
@@ -192,7 +192,7 @@ def get_data(begin_date,
 
         df = url2pandas(data_url, product)
         
-    # If the length the user specified data request is greater than 31 days, 
+    # If the length of the user specified data request is greater than 31 days, 
     # need to pull the data from API using requests of 31 day 'blocks' since 
     # NOAA API prohibits requests larger than 31 days
     else:
@@ -228,7 +228,8 @@ def get_data(begin_date,
             df_new = url2pandas(data_url, product)    # get dataframe for block 
             df = df.append(df_new)    # append to existing dataframe 
         
-    # rename output dataframe columns and convert to useable data types
+    # rename output dataframe columns based on requested product
+    # and convert to useable data types
     if product == 'water_level':
         # rename columns for clarity
         df.rename(columns = {'f': 'flags', 'q': 'QC', 's': 'sigma',
@@ -318,7 +319,8 @@ def get_data(begin_date,
         df['date_time'] = pd.to_datetime(df['date_time'])
 
 
-    df.index = df['date_time']    # set datetime to index (for use in resampling)
+    # set datetime to index (for use in resampling)
+    df.index = df['date_time']
     df = df.drop(columns=['date_time'])
 
     # handle hourly requests for water_level and currents data


### PR DESCRIPTION
This pull request is intended to fix #10 and #13 but the README examples currently fail the tests. Something is going on with the DatetimeIndex in the returned dataframes...

@delgadom , could use your help on this one if you are interested. Any idea what might be going on here? 

Code used as example in `README.md`, which I copy/pasted from running in the terminal: 

```python
>>> from py_noaa import coops
>>> df_currents = coops.get_data(
...     begin_date="20150727",
...     end_date="20150910",
...     stationid="PUG1515",
...     product="currents",
...     bin_num=1,
...     units="metric",
...     time_zone="gmt")
...
>>> df_currents.head()
                     bin  direction  speed
date_time
2015-07-27 20:06:00  1.0      255.0   32.1
2015-07-27 20:12:00  1.0      255.0   30.1
2015-07-27 20:18:00  1.0      261.0   29.3
2015-07-27 20:24:00  1.0      260.0   27.3
2015-07-27 20:30:00  1.0      261.0   23.0

```

When I run pytest, I get the following failures:
```
================================== FAILURES ===================================
_____________________________ [doctest] README.md _____________________________
059 >>> df_currents = coops.get_data(
060 ...     begin_date="20150727",
061 ...     end_date="20150910",
062 ...     stationid="PUG1515",
063 ...     product="currents",
064 ...     bin_num=1,
065 ...     units="metric",
066 ...     time_zone="gmt")
067 ...
068 >>> df_currents.head()
Differences (unified diff with -expected +actual):
    @@ -1,4 +1,4 @@
                          bin  direction  speed
    -date_time
    +date_time
     2015-07-27 20:06:00  1.0      255.0   32.1
     2015-07-27 20:12:00  1.0      255.0   30.1

```

For some reason pytest doesn't seem to handle the index `date_time` (which is a DatetimeIndex) properly? It is treating the first two lines of the dataframe as part of the index `date_time`?

 