### PR TITLE
upgrade pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=4.0
 pytest-cov
 pandas
 numpy


### PR DESCRIPTION
@GClunies for some reason travis is installing a really old version of pytest (see travis line [GClunies/py_noaa/jobs/531141656#490](https://travis-ci.org/GClunies/py_noaa/jobs/531141656#L490))

This PR requires pytest >= 4.0. The current version is 4.5.0. If this passes I think you should be good to go.